### PR TITLE
Variable name change to fix compile error.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,8 +19,8 @@ target_include_directories(dma-heap-unit-tests
 )
 
 target_link_libraries(dma-heap-unit-tests
-	${GTEST_LIBRARY}
-	${GTEST_MAIN_LIBRARY}
+	${GTEST_LIBRARIES}
+	${GTEST_MAIN_LIBRARIES}
 	pthread
 )
 


### PR DESCRIPTION
It appears that a recent change in the GTest CMake integration
changed the variable names for the libraries.  This fixes that
issue and makes the compile work under Yocto.

Signed-off-by: Ryan Eatmon <reatmon@ti.com>