### PR TITLE
CMakeLists: Move to CMake 3.8 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.8)
 project(dma-heap-tests)
 
 find_package(PkgConfig REQUIRED)


### PR DESCRIPTION
Move to minimal cmake version support to 3.8.